### PR TITLE
qt5: update source uri

### DIFF
--- a/recipes/qt5/qt5-5.3.1.inc
+++ b/recipes/qt5/qt5-5.3.1.inc
@@ -6,5 +6,5 @@ LICENSE = "GFDL-1.3 & LGPL-2.1 | GPL-3.0"
 QT_VERSION ?= "${PV}"
 
 SRC_URI += " \
-    http://download.qt-project.org/official_releases/qt/5.3/${PV}/submodules/${QT_MODULE}-opensource-src-${QT_VERSION}.tar.xz"
+    http://download.qt.io/archive/qt/5.3/5.3.1/submodules/${QT_MODULE}-opensource-src-${QT_VERSION}.tar.xz"
 S = "${SRCDIR}/${QT_MODULE}-opensource-src-${QT_VERSION}"


### PR DESCRIPTION
qt-5.3.1 has been moved from "official_releases" to "archive" on the qt
download page, so update the src uri accordingly.